### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,7 @@
     "highlight"
   ],
   "author": "Michal Dorner <dorner.michal@gmail.com> (http://dorny.github.io/)",
-  "license": {
-    "type": "MIT",
-    "url": "https://raw.github.com/dorny/codemirror-highlight-node/master/LICENSE"
-  },
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/dorny/codemirror-highlight-node/issues"
   },


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
